### PR TITLE
Add email templates for sendForgetPasswordOTP and sendPasswordChangeConfirmation events

### DIFF
--- a/src/emails/templates/forget-password-otp.tsx
+++ b/src/emails/templates/forget-password-otp.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { withEmailWrapper } from '../wrappers/withEmailWrapper';
+import { Section } from '@react-email/components';
+import { Typography } from '../components/ui/typography';
+
+interface ForgetPasswordOTPProps {
+  otp: string;
+  recipientName: string;
+}
+
+const ForgetPasswordOTPContent: React.FC<ForgetPasswordOTPProps> = ({ otp, recipientName }) => {
+  return (
+    <>
+      <Typography variant="h4" className="mb-6">
+        Hello {recipientName},
+      </Typography>
+      <Typography variant="p" className="mb-4">
+        We received a request to reset your password for your Ansopedia account. Please use the following One-Time
+        Password (OTP) to verify your identity:
+      </Typography>
+      <Typography variant="h4">This is your OTP: {otp}</Typography>
+      <Section className="bg-gray-100 rounded p-6 text-center my-6">
+        <Typography variant="h1" className="m-0 text-black">
+          {otp}
+        </Typography>
+      </Section>
+      <Typography variant="p" className="mb-4">
+        This OTP is valid for 10 minutes. If you didn't request this password reset, please ignore this email or contact
+        support immediately.
+      </Typography>
+    </>
+  );
+};
+
+export const ForgetPasswordOTP = withEmailWrapper(ForgetPasswordOTPContent, {
+  wrapperType: 'default',
+  previewText: 'Your Ansopedia Password Reset OTP',
+});
+
+export default ForgetPasswordOTP;

--- a/src/emails/templates/password-change-confirmation.tsx
+++ b/src/emails/templates/password-change-confirmation.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { withEmailWrapper } from '../wrappers/withEmailWrapper';
+import { Section } from '@react-email/components';
+import { Typography } from '../components/ui/typography';
+
+interface PasswordChangeConfirmationProps {
+  recipientName: string;
+}
+
+const PasswordChangeConfirmationContent: React.FC<PasswordChangeConfirmationProps> = ({ recipientName }) => {
+  return (
+    <>
+      <Typography variant="h4" className="mb-6">
+        Hello {recipientName},
+      </Typography>
+      <Typography variant="p" className="mb-4">
+        This is a confirmation that your password for your Ansopedia account has been successfully changed.
+      </Typography>
+      <Section className="bg-gray-100 rounded p-6 text-center my-6">
+        <Typography variant="h2" className="m-0 text-black">
+          Password Changed Successfully
+        </Typography>
+      </Section>
+      <Typography variant="p" className="mb-4">
+        If you did not make this change, please contact our support team immediately to secure your account.
+      </Typography>
+      <Typography variant="p" className="mb-4">
+        Thank you for using Ansopedia.
+      </Typography>
+    </>
+  );
+};
+
+export const PasswordChangeConfirmation = withEmailWrapper(PasswordChangeConfirmationContent, {
+  wrapperType: 'default',
+  previewText: 'Your Ansopedia Password Has Been Changed',
+});
+
+export default PasswordChangeConfirmation;


### PR DESCRIPTION
This PR addresses issue #15 by adding two new email templates:
- ForgetPasswordOTPContent for sendForgetPasswordOTP
- PasswordChangeConfirmationContent for sendPasswordChangeConfirmation

I've followed the structure of the existing EmailVerificationOTPContent component for consistency and used the reusable components as requested.

The templates are ready for testing with the email preview setup.